### PR TITLE
Potential fix for code scanning alert no. 9650: Information exposure through an exception

### DIFF
--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -506,7 +506,7 @@ def test_create_user():
         return jsonify({"success": True, "user_id": user.id}), 200
     except Exception as e:
         logger.error(f"Test user creation failed: {str(e)}", exc_info=True)
-        return jsonify({"success": False, "error": str(e)}), 500
+        return jsonify({"success": False, "error": "An internal error has occurred."}), 500
 
 
 @bp.route("/logout")


### PR DESCRIPTION
Potential fix for [https://github.com/henryperkins/chatter/security/code-scanning/9650](https://github.com/henryperkins/chatter/security/code-scanning/9650)

To fix the problem, we should avoid sending the raw exception message back to the user. Instead, we can log the detailed error message on the server and return a generic error message to the client. This approach ensures that sensitive information is not exposed while still allowing developers to debug issues using the server logs.

- Modify the `test_create_user` route to log the detailed exception message and return a generic error message in the JSON response.
- Ensure that the logging captures the full stack trace for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent the exposure of potentially sensitive information from exceptions by returning a generic error message to the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error messaging for user creation failures by displaying a generic error message, which enhances security by avoiding exposure of internal details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->